### PR TITLE
Add new Test mode: QRSS (FSK-CW + Chirped Hell)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ -e /usr/src/pico-sdk ]; then
+    export PICO_SDK_PATH=/usr/src/pico-sdk
+fi
+
+mkdir -p build
 cd build
 cmake ..
 make

--- a/defines.h
+++ b/defines.h
@@ -82,4 +82,9 @@
 
 #define asizeof(a) (sizeof (a) / sizeof ((a)[0]))
 
+#define RUN_TEST_FUNCTION_NAME(x) Spinner ## x ## Test()
+#define RUN_TEST(x) RUN_TEST_FUNCTION_NAME(x)
+#define Q(x) #x
+#define QUOTE(x) Q(x)
+
 #endif

--- a/protos.h
+++ b/protos.h
@@ -8,6 +8,8 @@
 void RAM (SpinnerMFSKTest)(void);
 void RAM (SpinnerSweepTest)(void);
 void RAM (SpinnerRTTYTest)(void);
+void RAM (SpinnerQRSSTest)(void);
+void RAM (QRSSChirpedHellSymbol)(uint8_t, uint8_t);
 void RAM (SpinnerMilliHertzTest)(void);
 void RAM (SpinnerWide4FSKTest)(void);
 void RAM (SpinnerGPSreferenceTest)(void);

--- a/test.c
+++ b/test.c
@@ -85,6 +85,7 @@
 #include "piodco/piodco.h"
 #include "build/dco2.pio.h"
 #include "hardware/vreg.h"
+#include "hardware/clocks.h"
 #include "pico/multicore.h"
 #include "pico/stdio/driver.h"
 


### PR DESCRIPTION
Dear Roman, 

thanks for making this project available!

I added a new test mode which produces a typical QRSS beacon transmission, with a Chirped Hell symbol plus FSK Morse code. Here's an example (with a little drift - no GPS locking):

![pico](https://github.com/user-attachments/assets/c7efa06c-a04c-4ca0-bb83-aad08be1b1a7)

I also added a little bit of code and macros to make it possible to select the different tests by defining a preprocessor symbol.

Feel free to merge if you like it, or ignore if you don't :-)

73
Fabian, DJ5CW