### PR TITLE
fixed undefined reference to set_sys_clock_khz

### DIFF
--- a/test.c
+++ b/test.c
@@ -7,13 +7,13 @@
 //
 //
 //  test.c - Simple tests of digital controlled radio freq oscillator.
-// 
+//
 //
 //  DESCRIPTION
 //
 //      The oscillator provides precise generation of any frequency ranging
 //  from 1 Hz to 33.333 MHz with tenth's of millihertz resolution (please note that
-//  this is relative resolution owing to the fact that the absolute accuracy of 
+//  this is relative resolution owing to the fact that the absolute accuracy of
 //  onboard crystal of pi pico is limited; the absoulte accuracy can be provided
 //  when using GPS reference option included).
 //      The DCO uses phase locked loop principle programmed in C and PIO asm.
@@ -45,7 +45,7 @@
 //      Raspberry Pi pico.
 //
 //  REVISION HISTORY
-// 
+//
 //      Rev 0.1   05 Nov 2023   Initial release
 //      Rev 0.2   18 Nov 2023
 //      Rev 1.0   10 Dec 2023   Improved frequency range (to ~33.333 MHz).
@@ -57,7 +57,7 @@
 //      MIT License (http://www.opensource.org/licenses/mit-license.php)
 //
 //  Copyright (c) 2023 by Roman Piksaykin
-//  
+//
 //  Permission is hereby granted, free of charge,to any person obtaining a copy
 //  of this software and associated documentation files (the Software), to deal
 //  in the Software without restriction,including without limitation the rights
@@ -76,35 +76,30 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 ///////////////////////////////////////////////////////////////////////////////
-#include <string.h>
-#include <stdlib.h>
+#include <GPStime.h>
+#include <hfconsole.h>
+#include <pico/stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
-#include "defines.h"
-
-#include "piodco/piodco.h"
+#include "./debug/logutils.h"
+#include "./lib/assert.h"
 #include "build/dco2.pio.h"
+#include "defines.h"
+#include "hardware/clocks.h"
 #include "hardware/vreg.h"
+#include "hwdefs.h"
 #include "pico/multicore.h"
 #include "pico/stdio/driver.h"
-
-#include "./lib/assert.h"
-#include "./debug/logutils.h"
-#include "hwdefs.h"
-
-#include <GPStime.h>
-
-#include <hfconsole.h>
-
+#include "piodco/piodco.h"
 #include "protos.h"
 
-//#define GEN_FRQ_HZ 32333333L
+// #define GEN_FRQ_HZ 32333333L
 #define GEN_FRQ_HZ 29977777L
 
 PioDco DCO; /* External in order to access in both cores. */
 
-int main() 
-{
+int main() {
     const uint32_t clkhz = PLL_SYS_MHZ * 1000000L;
     set_sys_clock_khz(clkhz / 1000L, true);
 
@@ -120,8 +115,7 @@ int main()
 
     multicore_launch_core1(core1_entry);
 
-    for(;;)
-    {
+    for (;;) {
         gpio_put(PICO_DEFAULT_LED_PIN, 0);
         sleep_ms(5);
         int r = HFconsoleProcess(phfc, 10);
@@ -129,31 +123,29 @@ int main()
         sleep_ms(1);
     }
 
-    for(;;)
-    {
+    for (;;) {
         sleep_ms(100);
-        int chr = getchar_timeout_us(100);//getchar();
+        int chr = getchar_timeout_us(100);  // getchar();
         printf("%d %c\n", chr, (char)chr);
     }
-  
+
     gpio_init(PICO_DEFAULT_LED_PIN);
     gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
 
     multicore_launch_core1(core1_entry);
 
-    //SpinnerDummyTest();
-    //SpinnerSweepTest();
-    //SpinnerMFSKTest();
+    // SpinnerDummyTest();
+    // SpinnerSweepTest();
+    // SpinnerMFSKTest();
     SpinnerRTTYTest();
-    //SpinnerMilliHertzTest();
-    //SpinnerWide4FSKTest();
-    //SpinnerGPSreferenceTest();
+    // SpinnerMilliHertzTest();
+    // SpinnerWide4FSKTest();
+    // SpinnerGPSreferenceTest();
 }
 
-/* This is the code of dedicated core. 
+/* This is the code of dedicated core.
    We deal with extremely precise real-time task. */
-void core1_entry()
-{
+void core1_entry() {
     const uint32_t clkhz = PLL_SYS_MHZ * 1000000L;
 
     /* Initialize DCO */
@@ -169,15 +161,13 @@ void core1_entry()
     PioDCOWorker2(&DCO);
 }
 
-void RAM (SpinnerMFSKTest)(void)
-{
+void RAM(SpinnerMFSKTest)(void) {
     uint32_t rndval = 77777777;
-    for(;;)
-    {
+    for (;;) {
         /* This example sets new RND frequency every ~250 ms.
            Frequency shift is 5 Hz for each step.
         */
-        PioDCOSetFreq(&DCO, GEN_FRQ_HZ - 5*(rndval & 7), 0u);
+        PioDCOSetFreq(&DCO, GEN_FRQ_HZ - 5 * (rndval & 7), 0u);
 
         /* LED signal */
         gpio_put(PICO_DEFAULT_LED_PIN, 1);
@@ -189,15 +179,13 @@ void RAM (SpinnerMFSKTest)(void)
     }
 }
 
-void RAM (SpinnerSweepTest)(void)
-{
+void RAM(SpinnerSweepTest)(void) {
     int i = 0;
-    for(;;)
-    {
+    for (;;) {
         /* This example sets new frequency every ~250 ms.
            Frequency shift is 5 Hz for each step.
         */
-        PioDCOSetFreq(&DCO, GEN_FRQ_HZ - 5*i, 0u);
+        PioDCOSetFreq(&DCO, GEN_FRQ_HZ - 5 * i, 0u);
 
         /* LED signal */
         gpio_put(PICO_DEFAULT_LED_PIN, 1);
@@ -206,21 +194,18 @@ void RAM (SpinnerSweepTest)(void)
         sleep_ms(500);
 
         /* Return to initial freq after 20 steps (100 Hz). */
-        if(++i == 20)
-            i = 0;
+        if (++i == 20) i = 0;
     }
 }
 
-void RAM (SpinnerRTTYTest)(void)
-{
-    int32_t df = 170;   /* 170 Hz freq diff. */
+void RAM(SpinnerRTTYTest)(void) {
+    int32_t df = 170; /* 170 Hz freq diff. */
     uint32_t rndval = 77777777;
-    for(;;)
-    {
+    for (;;) {
         /* This example sets new PRN frequency every ~22 ms.
            Note: You should use precise timing while building a real transmitter.
         */
-        PioDCOSetFreq(&DCO, GEN_FRQ_HZ - df*(rndval & 1), 0u);
+        PioDCOSetFreq(&DCO, GEN_FRQ_HZ - df * (rndval & 1), 0u);
 
         /* LED signal */
         gpio_put(PICO_DEFAULT_LED_PIN, 1);
@@ -232,15 +217,13 @@ void RAM (SpinnerRTTYTest)(void)
     }
 }
 
-void RAM (SpinnerMilliHertzTest)(void)
-{
+void RAM(SpinnerMilliHertzTest)(void) {
     int i = 0;
-    for(;;)
-    {
+    for (;;) {
         /* This example sets new frequency every ~1s.
            Frequency shift is 0.99 Hz for each step.
         */
-        PioDCOSetFreq(&DCO, GEN_FRQ_HZ, 990*(++i&1));
+        PioDCOSetFreq(&DCO, GEN_FRQ_HZ, 990 * (++i & 1));
 
         /* LED signal */
         gpio_put(PICO_DEFAULT_LED_PIN, 1);
@@ -250,16 +233,14 @@ void RAM (SpinnerMilliHertzTest)(void)
     }
 }
 
-void RAM (SpinnerWide4FSKTest)(void)
-{
-    int32_t df = 100;   /* 100 Hz freq diff * 4 = 400 Hz. */
+void RAM(SpinnerWide4FSKTest)(void) {
+    int32_t df = 100; /* 100 Hz freq diff * 4 = 400 Hz. */
     uint32_t rndval = 77777777;
-    for(;;)
-    {
+    for (;;) {
         /* This example sets new PRN frequency every ~20 ms.
            Note: You should use precise timing while building a real transmitter.
         */
-        PioDCOSetFreq(&DCO, GEN_FRQ_HZ - df*(rndval & 3), 0u);
+        PioDCOSetFreq(&DCO, GEN_FRQ_HZ - df * (rndval & 3), 0u);
 
         /* LED signal */
         gpio_put(PICO_DEFAULT_LED_PIN, 1);
@@ -278,8 +259,7 @@ void RAM (SpinnerWide4FSKTest)(void)
    accurate PPS output (pulse per second). If no such option,
    the correction parameter is zero.
 */
-void RAM (SpinnerGPSreferenceTest)(void)
-{
+void RAM(SpinnerGPSreferenceTest)(void) {
     const uint32_t ku32_freq = 5555000UL;
     const int kigps_pps_pin = 2;
 
@@ -289,25 +269,22 @@ void RAM (SpinnerGPSreferenceTest)(void)
     assert_(pGPS);
     DCO._pGPStime = pGPS;
     int tick = 0;
-    for(;;)
-    {
-        PioDCOSetFreq(&DCO, ku32_freq, -2*i32_compensation_millis);
+    for (;;) {
+        PioDCOSetFreq(&DCO, ku32_freq, -2 * i32_compensation_millis);
 
         /* LED signal */
         gpio_put(PICO_DEFAULT_LED_PIN, 1);
         sleep_ms(2500);
 
-        i32_compensation_millis = 
-            PioDCOGetFreqShiftMilliHertz(&DCO, (uint64_t)(ku32_freq * 1000LL));
+        i32_compensation_millis = PioDCOGetFreqShiftMilliHertz(&DCO, (uint64_t)(ku32_freq * 1000LL));
 
         gpio_put(PICO_DEFAULT_LED_PIN, 0);
         sleep_ms(2500);
 
-        if(0 == ++tick % 6)
-        {
-            //stdio_set_driver_enabled(&stdio_uart, false);
+        if (0 == ++tick % 6) {
+            // stdio_set_driver_enabled(&stdio_uart, false);
             GPStimeDump(&(pGPS->_time_data));
-            //stdio_set_driver_enabled(&stdio_uart, true);
+            // stdio_set_driver_enabled(&stdio_uart, true);
         }
     }
 }


### PR DESCRIPTION
Changes to the SDK now require <pico/stdlib.h> not <stdlib.h> and must include "hardware/clocks.h" - thanks to https://forums.raspberrypi.com/viewtopic.php?t=375419 for the info.